### PR TITLE
Fixed search by Query provider

### DIFF
--- a/main/src/main/java/com/github/topisenpai/lavasrc/mirror/MirroringAudioTrack.java
+++ b/main/src/main/java/com/github/topisenpai/lavasrc/mirror/MirroringAudioTrack.java
@@ -78,7 +78,7 @@ public abstract class MirroringAudioTrack extends DelegatedAudioTrack {
 
             provider = provider.replace(QUERY_PATTERN, getTrackTitle());
             track = loadItem(provider);
-            if (track != null) {
+            if (track != AudioReference.NO_TRACK) {
                 break;
             }
         }


### PR DESCRIPTION
All classes now use AudioReference.NO_TRACK instead of "null". However, there was a place where "null" was still expected. Because of this, there was only search by ISRC. The search by "Query" was ignored. Fixed.