### PR TITLE
fix apple music token fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ plugins:
       countryCode: "US" # the country code you want to use for filtering the artists top tracks. See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
     applemusic:
       countryCode: "US" # the country code you want to use for filtering the artists top tracks and language. See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+      mediaAPIToken: "..." # Can be used to bypass the auto token fetching which is likely to break again in the future
     deezer:
       masterDecryptionKey: "your master decryption key" # the master key used for decrypting the deezer tracks. (yes this is not here you need to get it from somewhere else)
     yandexmusic:

--- a/application.yml.example
+++ b/application.yml.example
@@ -3,23 +3,24 @@ plugins:
     providers: # Custom providers for track loading. This is the default
       - "ytsearch:\"%ISRC%\"" # Will be ignored if track does not have an ISRC. See https://en.wikipedia.org/wiki/International_Standard_Recording_Code
       - "ytsearch:%QUERY%" # Will be used if track has no ISRC or no track could be found for the ISRC
-    # - "dzisrc:%ISRC%"
+    # - "dzisrc:%ISRC%" # Deezer ISRC provider
     # - "scsearch:%QUERY%" you can add multiple other fallback sources here
     sources:
       spotify: true # Enable Spotify source
       applemusic: true # Enable Apple Music source
-      deezer: true
-      yandexmusic: true
+      deezer: true # Enable Deezer source
+      yandexmusic: true # Enable Yandex Music source
     spotify:
-      clientId: "..."
-      clientSecret: "..."
-      countryCode: "US"
+      clientId: "your client id"
+      clientSecret: "your client secret"
+      countryCode: "US" # the country code you want to use for filtering the artists top tracks. See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
     applemusic:
-      countryCode: "US"
+      countryCode: "US" # the country code you want to use for filtering the artists top tracks and language. See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+      mediaAPIToken: "..." # Can be used to bypass the auto token fetching which is likely to break again in the future
     deezer:
-      masterDecryptionKey: "..."
+      masterDecryptionKey: "your master decryption key" # the master key used for decrypting the deezer tracks. (yes this is not here you need to get it from somewhere else)
     yandexmusic:
-      accessToken: "..."
+      accessToken: "your access token" # the token used for accessing the yandex music api. See https://github.com/TopiSenpai/LavaSrc#yandex-music
 
 server: # REST and WS server
   port: 2333

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -8,6 +8,7 @@ var moduleName = "lavasrc"
 dependencies {
     compileOnly "com.github.walkyst:lavaplayer-fork:1.3.98.4"
     implementation "org.jsoup:jsoup:1.14.3"
+    implementation "commons-io:commons-io:2.6"
 }
 
 publishing {

--- a/main/src/main/java/com/github/topisenpai/lavasrc/applemusic/AppleMusicSourceManager.java
+++ b/main/src/main/java/com/github/topisenpai/lavasrc/applemusic/AppleMusicSourceManager.java
@@ -158,7 +158,7 @@ public class AppleMusicSourceManager extends MirroringAudioSourceManager impleme
         var request = new HttpGet(uri);
         request.addHeader("Authorization", "Bearer " + this.getToken());
         if (this.origin != null && !this.origin.isEmpty()) {
-            request.addHeader("Origin", this.origin);
+            request.addHeader("Origin", "https://" + this.origin);
         }
         return HttpClientTools.fetchResponseAsJson(this.httpInterfaceManager.getInterface(), request);
     }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,8 +10,8 @@ mainClassName = "org.springframework.boot.loader.JarLauncher"
 
 dependencies {
     compileOnly("dev.arbjerg.lavalink:plugin-api:3.6.1")
-    implementation project(':main')
     runtimeOnly("com.github.freyacodes.lavalink:Lavalink-Server:3.6.0")
+    implementation project(":main")
 }
 
 shadowJar {

--- a/plugin/src/main/java/com/github/topisenpai/lavasrc/plugin/AppleMusicConfig.java
+++ b/plugin/src/main/java/com/github/topisenpai/lavasrc/plugin/AppleMusicConfig.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 public class AppleMusicConfig {
 
     private String countryCode = "us";
+    private String mediaAPIToken;
 
     public String getCountryCode() {
         return this.countryCode;
@@ -15,6 +16,14 @@ public class AppleMusicConfig {
 
     public void setCountryCode(String countryCode) {
         this.countryCode = countryCode;
+    }
+
+    public String getMediaAPIToken() {
+        return this.mediaAPIToken;
+    }
+
+    public void setMediaAPIToken(String mediaAPIToken) {
+        this.mediaAPIToken = mediaAPIToken;
     }
 
 }

--- a/plugin/src/main/java/com/github/topisenpai/lavasrc/plugin/LavaSrcPlugin.java
+++ b/plugin/src/main/java/com/github/topisenpai/lavasrc/plugin/LavaSrcPlugin.java
@@ -41,7 +41,7 @@ public class LavaSrcPlugin implements AudioPlayerManagerConfiguration {
         }
         if (this.sourcesConfig.isAppleMusic()) {
             log.info("Registering Apple Music audio source manager...");
-            manager.registerSourceManager(new AppleMusicSourceManager(this.pluginConfig.getProviders(), this.appleMusicConfig.getCountryCode(), manager));
+            manager.registerSourceManager(new AppleMusicSourceManager(this.pluginConfig.getProviders(), this.appleMusicConfig.getMediaAPIToken(), this.appleMusicConfig.getCountryCode(), manager));
         }
         if (this.sourcesConfig.isDeezer()) {
             log.info("Registering Deezer audio source manager...");


### PR DESCRIPTION
This is kind of a dirty workaround tbh
regexing the token out of a js file is terrible and is likely to break again
if you have any better idea feel free to suggest.

I added a config option to bypass the auto fetching. As of now their token is valid until 23th jan 2023.
If it breaks you can just extract the jwt token yourself and override it basically