### PR TITLE
Use dzsearch in the example when mentioning deezer

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ plugins:
   lavasrc:
     providers: # Custom providers for track loading. This is the default
       # - "dzisrc:%ISRC%" # Deezer ISRC provider
-      # - "scsearch:%QUERY%" # Deezer search provider
+      # - "dzsearch:%QUERY%" # Deezer search provider
       - "ytsearch:\"%ISRC%\"" # Will be ignored if track does not have an ISRC. See https://en.wikipedia.org/wiki/International_Standard_Recording_Code
       - "ytsearch:%QUERY%" # Will be used if track has no ISRC or no track could be found for the ISRC
       #  you can add multiple other fallback sources here

--- a/application.yml.example
+++ b/application.yml.example
@@ -2,7 +2,7 @@ plugins:
   lavasrc:
     providers: # Custom providers for track loading. This is the default
       # - "dzisrc:%ISRC%" # Deezer ISRC provider
-      # - "scsearch:%QUERY%" # Deezer search provider
+      # - "dzsearch:%QUERY%" # Deezer search provider
       - "ytsearch:\"%ISRC%\"" # Will be ignored if track does not have an ISRC. See https://en.wikipedia.org/wiki/International_Standard_Recording_Code
       - "ytsearch:%QUERY%" # Will be used if track has no ISRC or no track could be found for the ISRC
       #  you can add multiple other fallback sources here


### PR DESCRIPTION
`dzsearch` as mentioned below is the actual query prefix for deezer search. The example uses `scsearch` but commented as if that is deezer.
