### PR TITLE
Fix null checks for JSON responses in Yandex Music source

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -100,12 +100,15 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 				+ "&type=all"
 				+ "&page=0"
 		);
+		if (json == null) {
+			return AudioSearchResult.EMPTY;
+		}
 		if (setOfTypes.isEmpty()) {
 			setOfTypes = SEARCH_TYPES;
 		}
 
 		var resultJson = json.get("result");
-		if (json.isNull() || resultJson.isNull()) {
+		if (resultJson.isNull()) {
 			return AudioSearchResult.EMPTY;
 		}
 
@@ -343,7 +346,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 		}
 
 		var json = this.getJson(PUBLIC_API_BASE + "/tracks/" + identifier + "/similar");
-		if (json.isNull() || json.get("result").isNull() || json.get("result").get("similarTracks").values().isEmpty()) {
+		if (json == null || json.get("result").isNull() || json.get("result").get("similarTracks").values().isEmpty()) {
 			return AudioReference.NO_TRACK;
 		}
 		var tracks = this.parseTracks(json.get("result").get("similarTracks"), "com");
@@ -363,7 +366,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 
 	private AudioItem getSearch(String query) throws IOException {
 		var json = this.getJson(PUBLIC_API_BASE + "/search?text=" + URLEncoder.encode(query, StandardCharsets.UTF_8) + "&type=track&page=0");
-		if (json.isNull() || json.get("result").get("tracks").isNull()) {
+		if (json == null || json.get("result").get("tracks").isNull()) {
 			return AudioReference.NO_TRACK;
 		}
 		var tracks = this.parseTracks(json.get("result").get("tracks").get("results"), "com");
@@ -375,7 +378,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 
 	private AudioItem getAlbum(String id, String domainEnd) throws IOException {
 		var json = this.getJson(PUBLIC_API_BASE + "/albums/" + id + "/with-tracks?page-size=" + ALBUM_MAX_PAGE_ITEMS * albumLoadLimit);
-		if (json.isNull() || json.get("result").isNull()) {
+		if (json == null || json.get("result").isNull()) {
 			return AudioReference.NO_TRACK;
 		}
 		var tracks = new ArrayList<AudioTrack>();
@@ -404,7 +407,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 
 	private AudioItem getTrack(String id, String domainEnd) throws IOException {
 		var json = this.getJson(PUBLIC_API_BASE + "/tracks/" + id);
-		if (json.isNull() || json.get("result").values().get(0).get("available").text().equals("false")) {
+		if (json == null || json.get("result").values().get(0).get("available").text().equals("false")) {
 			return AudioReference.NO_TRACK;
 		}
 		return this.parseTrack(json.get("result").values().get(0), domainEnd);
@@ -412,7 +415,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 
 	private AudioItem getArtist(String id, String domainEnd) throws IOException {
 		var json = this.getJson(PUBLIC_API_BASE + "/artists/" + id + "/tracks?page-size=" + ARTIST_MAX_PAGE_ITEMS * artistLoadLimit);
-		if (json.isNull() || json.get("result").values().isEmpty()) {
+		if (json == null || json.get("result").values().isEmpty()) {
 			return AudioReference.NO_TRACK;
 		}
 
@@ -422,6 +425,9 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 		}
 
 		var artistJsonResponse = this.getJson(PUBLIC_API_BASE + "/artists/" + id);
+		if (artistJsonResponse == null) {
+			return AudioReference.NO_TRACK;
+		}
 		var artistJson = artistJsonResponse.get("result").get("artist");
 		var author = artistJson.get("name").text();
 
@@ -457,7 +463,7 @@ public class YandexMusicSourceManager extends ExtendedAudioSourceManager impleme
 	}
 
 	private AudioItem getPlaylist(JsonBrowser json, String domainEnd, String playlistUrl) {
-		if (json.isNull() || json.get("result").isNull() || json.get("result").get("tracks").values().isEmpty()) {
+		if (json == null || json.get("result").isNull() || json.get("result").get("tracks").values().isEmpty()) {
 			return AudioReference.NO_TRACK;
 		}
 		var tracks = this.parseTracks(json.get("result").get("tracks"), domainEnd);


### PR DESCRIPTION
Previously, JSON responses was checked using `isNull()`. I updated this to a simple `== null` check, since `LavaSrcTools.fetchResponseAsJson()` returns `null` in case of 404 error and `isNull()` just can't be called. And this approach is more consistent with other source managers.

This fixes confusing `/loadtracks` responses when fetching non-existing playlists/albums/tracks.
Example: https://music.yandex.ru/playlists/aaaaaa-aaa-aaa-aaaaaa
<details>
  <summary>Before</summary>

```
{
	"loadType": "error",
	"data": {
		"message": "Something went wrong while looking up the track.",
		"severity": "fault",
		"cause": "com.sedmelluq.discord.lavaplayer.tools.FriendlyException: Something went wrong while looking up the track.",
		"causeStackTrace": "com.sedmelluq.discord.lavaplayer.tools.FriendlyException: Something went wrong while looking up the track.\r\n\tat lavalink.server.util.LoadingKt.loadAudioItem(loading.kt:20)\r\n\tat lavalink.server.player.AudioLoaderRestHandler.loadTracks(AudioLoaderRestHandler.kt:59)\r\n\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)\r\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\r\n\tat kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)\r\n\tat kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Instance.call(CallerImpl.kt:113)\r\n\tat kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:207)\r\n\tat kotlin.reflect.jvm.internal.KCallableImpl.callBy(KCallableImpl.kt:112)\r\n\tat org.springframework.web.method.support.InvocableHandlerMethod$KotlinDelegate.invokeFunction(InvocableHandlerMethod.java:334)\r\n\tat org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:252)\r\n\tat org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188)\r\n\tat org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)\r\n\tat org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:926)\r\n\tat org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:831)\r\n\tat org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)\r\n\tat org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089)\r\n\tat org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979)\r\n\tat org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)\r\n\tat org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903)\r\n\tat jakarta.servlet.http.HttpServlet.service(HttpServlet.java:527)\r\n\tat org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885)\r\n\tat jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)\r\n\tat io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)\r\n\tat io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)\r\n\tat org.springframework.web.filter.AbstractRequestLoggingFilter.doFilterInternal(AbstractRequestLoggingFilter.java:289)\r\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)\r\n\tat io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:67)\r\n\tat io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)\r\n\tat lavalink.server.io.ResponseHeaderFilter.doFilterInternal(ResponseHeaderFilter.kt:17)\r\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)\r\n\tat io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:67)\r\n\tat io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)\r\n\tat org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)\r\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)\r\n\tat io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:67)\r\n\tat io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)\r\n\tat io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)\r\n\tat io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)\r\n\tat io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)\r\n\tat io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)\r\n\tat io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:68)\r\n\tat io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:117)\r\n\tat io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)\r\n\tat io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)\r\n\tat io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)\r\n\tat io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)\r\n\tat io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)\r\n\tat io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)\r\n\tat io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)\r\n\tat io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)\r\n\tat io.undertow.servlet.handlers.SendErrorPageHandler.handleRequest(SendErrorPageHandler.java:52)\r\n\tat io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)\r\n\tat io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:276)\r\n\tat io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)\r\n\tat io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:132)\r\n\tat io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)\r\n\tat io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)\r\n\tat io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:256)\r\n\tat io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:101)\r\n\tat io.undertow.server.Connectors.executeRootHandler(Connectors.java:393)\r\n\tat io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:859)\r\n\tat org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)\r\n\tat org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)\r\n\tat org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1512)\r\n\tat org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)\r\n\tat java.base/java.lang.Thread.run(Thread.java:1583)\r\nCaused by: java.lang.NullPointerException: Cannot invoke \"com.sedmelluq.discord.lavaplayer.tools.JsonBrowser.isNull()\" because \"json\" is null\r\n\tat com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager.getPlaylist(YandexMusicSourceManager.java:466)\r\n\tat com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager.getPlaylist(YandexMusicSourceManager.java:452)\r\n\tat com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager.loadItem(YandexMusicSourceManager.java:326)\r\n\tat com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItemOnce(DefaultAudioPlayerManager.java:442)\r\n\tat com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItem(DefaultAudioPlayerManager.java:423)\r\n\tat com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.loadItemSync(DefaultAudioPlayerManager.java:154)\r\n\tat com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager.loadItemSync(AudioPlayerManager.java:127)\r\n\tat lavalink.server.util.LoadingKt.loadAudioItem(loading.kt:15)\r\n\t... 65 more\r\n"
	}
}
```
</details>
<details>
  <summary>After</summary>

  ```
  {
      "loadType": "empty",
      "data": null
  }
  ```
</details>


