### PR TITLE
Fix(spotify): Disable loadLyrics when disabled by config

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
@@ -72,27 +72,27 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 	
 
 	public SpotifySourceManager(String[] providers, String clientId, String clientSecret, String countryCode, AudioPlayerManager audioPlayerManager) {
-		this(clientId, clientSecret, null, countryCode, unused -> audioPlayerManager, new DefaultMirroringAudioTrackResolver(providers));
+		this(clientId, clientSecret, false, null, null, countryCode, unused -> audioPlayerManager, new DefaultMirroringAudioTrackResolver(providers), false);
 	}
 
 	public SpotifySourceManager(String[] providers, String clientId, String clientSecret, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager) {
-		this(clientId, clientSecret, null, countryCode, audioPlayerManager, new DefaultMirroringAudioTrackResolver(providers));
+		this(clientId, clientSecret, false, null, null, countryCode, audioPlayerManager, new DefaultMirroringAudioTrackResolver(providers), false);
 	}
 
 	public SpotifySourceManager(String clientId, String clientSecret, String countryCode, AudioPlayerManager audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver) {
-		this(clientId, clientSecret, null, countryCode, unused -> audioPlayerManager, mirroringAudioTrackResolver);
+		this(clientId, clientSecret, false, null, null, countryCode, unused -> audioPlayerManager, mirroringAudioTrackResolver, false);
 	}
 
 	public SpotifySourceManager(String clientId, String clientSecret, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver) {
-		this(clientId, clientSecret, null, countryCode, audioPlayerManager, mirroringAudioTrackResolver);
+		this(clientId, clientSecret, false, null, null, countryCode, audioPlayerManager, mirroringAudioTrackResolver, false);
 	}
 
 	public SpotifySourceManager(String clientId, String clientSecret, String spDc, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver) {
-		this(clientId, clientSecret, false , spDc, countryCode, audioPlayerManager, mirroringAudioTrackResolver);
+		this(clientId, clientSecret, false , null, spDc, countryCode, audioPlayerManager, mirroringAudioTrackResolver, false);
 	}
 
 	public SpotifySourceManager(String clientId, String clientSecret, boolean preferAnonymousToken, String spDc, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver) {
-		this(clientId, clientSecret, preferAnonymousToken, null, spDc, countryCode, audioPlayerManager, mirroringAudioTrackResolver);
+		this(clientId, clientSecret, preferAnonymousToken, null, spDc, countryCode, audioPlayerManager, mirroringAudioTrackResolver, false);
 	}
 
 	public SpotifySourceManager(String clientId, String clientSecret, boolean preferAnonymousToken, String customTokenEndpoint, String spDc, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver, boolean lyricsEnabled) {

--- a/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
@@ -59,6 +59,8 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 	public static final Set<AudioSearchResult.Type> SEARCH_TYPES = Set.of(AudioSearchResult.Type.ALBUM, AudioSearchResult.Type.ARTIST, AudioSearchResult.Type.PLAYLIST, AudioSearchResult.Type.TRACK);
 	private static final Logger log = LoggerFactory.getLogger(SpotifySourceManager.class);
 
+	private final boolean lyricsEnabled;
+
 	private final HttpInterfaceManager httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager();
 	private final SpotifyTokenTracker tokenTracker;
 	private final String countryCode;
@@ -93,7 +95,7 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 		this(clientId, clientSecret, preferAnonymousToken, null, spDc, countryCode, audioPlayerManager, mirroringAudioTrackResolver);
 	}
 
-	public SpotifySourceManager(String clientId, String clientSecret, boolean preferAnonymousToken, String customTokenEndpoint, String spDc, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver) {
+	public SpotifySourceManager(String clientId, String clientSecret, boolean preferAnonymousToken, String customTokenEndpoint, String spDc, String countryCode, Function<Void, AudioPlayerManager> audioPlayerManager, MirroringAudioTrackResolver mirroringAudioTrackResolver, boolean lyricsEnabled) {
 		super(audioPlayerManager, mirroringAudioTrackResolver);
 
 		this.tokenTracker = new SpotifyTokenTracker(this, clientId, clientSecret, spDc, customTokenEndpoint);
@@ -103,6 +105,7 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 		}
 		this.countryCode = countryCode;
 		this.preferAnonymousToken = preferAnonymousToken;
+		this.lyricsEnabled = lyricsEnabled;
 	}
 
 	public void setPlaylistPageLimit(int playlistPageLimit) {
@@ -146,6 +149,10 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 	@Override
 	@Nullable
 	public AudioLyrics loadLyrics(@NotNull AudioTrack audioTrack) {
+		if (!this.lyricsEnabled) {
+            return null;
+        }
+		
 		var spotifyTackId = "";
 		if (audioTrack instanceof SpotifyAudioTrack) {
 			spotifyTackId = audioTrack.getIdentifier();

--- a/plugin/src/main/java/com/github/topi314/lavasrc/plugin/LavaSrcPlugin.java
+++ b/plugin/src/main/java/com/github/topi314/lavasrc/plugin/LavaSrcPlugin.java
@@ -75,7 +75,8 @@ public class LavaSrcPlugin implements AudioPlayerManagerConfiguration, SearchMan
 		this.lyricsSourcesConfig = lyricsSourcesConfig;
 
 		if (sourcesConfig.isSpotify() || lyricsSourcesConfig.isSpotify()) {
-			this.spotify = new SpotifySourceManager(spotifyConfig.getClientId(), spotifyConfig.getClientSecret(), spotifyConfig.isPreferAnonymousToken(), spotifyConfig.getCustomTokenEndpoint(), spotifyConfig.getSpDc(), spotifyConfig.getCountryCode(), unused -> manager, new DefaultMirroringAudioTrackResolver(pluginConfig.getProviders()));
+			boolean isLyricsEnabled = lyricsSourcesConfig.isSpotify();
+			this.spotify = new SpotifySourceManager(spotifyConfig.getClientId(), spotifyConfig.getClientSecret(), spotifyConfig.isPreferAnonymousToken(), spotifyConfig.getCustomTokenEndpoint(), spotifyConfig.getSpDc(), spotifyConfig.getCountryCode(), unused -> manager, new DefaultMirroringAudioTrackResolver(pluginConfig.getProviders()), isLyricsEnabled);
 			if (spotifyConfig.getPlaylistLoadLimit() > 0) {
 				this.spotify.setPlaylistPageLimit(spotifyConfig.getPlaylistLoadLimit());
 			}


### PR DESCRIPTION
Fixes an issue where Spotify lyrics logic executed even if explicitly disabled via configuration.

The core problem: SpotifySourceManager implements AudioLyricsManager, causing it to be called by the LavaLyrics fallback mechanism whenever a Spotify track was loaded, even if 'lyrics-sources: spotify: false'.

This unintended invocation of loadLyrics() triggered the required logic to obtain an Account Token (checking spDc or customTokenEndpoint). If this token source was misconfigured or unavailable, it resulted in persistent 'Connection refused' errors in the logs, despite the user only enabling Spotify for audio playback.

### Implementation Details:

1.  **Guard Clause:** Added a 'boolean lyricsEnabled' flag to SpotifySourceManager.
2.  **Logic Bypass:** loadLyrics() now checks this flag and returns null immediately if disabled.
3.  **Plugin Update:** LavaSrcPlugin.java now explicitly passes the value of lyricsSourcesConfig.isSpotify() to the SpotifySourceManager constructor, making lyrics functionality strictly opt-in.