### PR TITLE
Return empty playlist when it exists but has no playable tracks or empty

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
@@ -490,10 +490,6 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 		}
 		while (page.get("next").text() != null && ++pages < this.playlistPageLimit);
 
-		if (tracks.isEmpty()) {
-			return AudioReference.NO_TRACK;
-		}
-
 		return new SpotifyAudioPlaylist(json.get("name").safeText(), tracks, ExtendedAudioPlaylist.Type.PLAYLIST, json.get("external_urls").get("spotify").text(), json.get("images").index(0).get("url").text(), json.get("owner").get("display_name").text(), (int) json.get("tracks").get("total").asLong(0));
 	}
 


### PR DESCRIPTION
Previously, `getPlaylist()` returned `AudioReference.NO_TRACK` if `tracks.isEmpty()` after loading all pages — even when playlist was successfully retrieved. This caused valid/existing empty playlists (or those with only episodes/local files) to trigger `noMatches()`, same as non-existent or private playlists.

This change removes the `if (tracks.isEmpty()) return NO_TRACK;` check. Now, if the playlist exists and metadata loads, a `SpotifyAudioPlaylist` is returned — even with zero tracks. `NO_TRACK` is only returned when the playlist itself cannot be accessed (`json == null`).

This allows empty but valid playlists to be recognized and handled properly instead of being treated as a complete failure.