### PR TITLE
feat: add legacy CDN key support for Deezer fallback mechanism

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -53,6 +53,7 @@ plugins:
       masterDecryptionKey: "your master decryption key" # the master key used for decrypting the deezer tracks. (yes this is not here you need to get it from somewhere else)
       arl: "your deezer arl" # the arl cookie used for accessing the deezer api this is not optional anymore
       formats: [ "FLAC", "MP3_320", "MP3_256", "MP3_128", "MP3_64", "AAC_64" ] # the formats you want to use for the deezer tracks. "FLAC", "MP3_320", "MP3_256" & "AAC_64" are only available for premium users and require a valid arl
+      legacyCdnKey: "" # optional key for legacy CDN URL fallback when media/get_url fails
     yandexmusic:
       accessToken: "your access token" # the token used for accessing the yandex music api. See https://github.com/topi314/LavaSrc#yandex-music
       playlistLoadLimit: 1 # The number of pages at 100 tracks each

--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
@@ -63,6 +63,7 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 	private final DeezerTokenTracker tokenTracker;
 	private final HttpInterfaceManager httpInterfaceManager;
 	private DeezerAudioTrack.TrackFormat[] formats;
+	private String legacyCdnKey;
 
 	public DeezerAudioSourceManager(String masterDecryptionKey) {
 		this(masterDecryptionKey, null);
@@ -73,6 +74,10 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 	}
 
 	public DeezerAudioSourceManager(String masterDecryptionKey, @Nullable String arl, @Nullable DeezerAudioTrack.TrackFormat[] formats) {
+		this(masterDecryptionKey, arl, formats, null);
+	}
+
+	public DeezerAudioSourceManager(String masterDecryptionKey, @Nullable String arl, @Nullable DeezerAudioTrack.TrackFormat[] formats, @Nullable String legacyCdnKey) {
 		if (masterDecryptionKey == null || masterDecryptionKey.isEmpty()) {
 			throw new IllegalArgumentException("Deezer master key must be set");
 		}
@@ -82,6 +87,7 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 		}
 
 		this.masterDecryptionKey = masterDecryptionKey;
+		this.legacyCdnKey = legacyCdnKey;
 		this.tokenTracker = new DeezerTokenTracker(this, arl);
 		this.formats = formats != null && formats.length > 0 ? formats : DeezerAudioTrack.TrackFormat.DEFAULT_FORMATS;
 		this.httpInterfaceManager = HttpClientTools.createCookielessThreadLocalManager();
@@ -572,5 +578,13 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 
 	public DeezerTokenTracker getTokenTracker() {
 		return this.tokenTracker;
+	}
+
+	public String getLegacyCdnKey() {
+		return this.legacyCdnKey;
+	}
+
+	public void setLegacyCdnKey(String legacyCdnKey) {
+		this.legacyCdnKey = legacyCdnKey;
 	}
 }

--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioTrack.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioTrack.java
@@ -27,9 +27,12 @@ import org.apache.http.impl.cookie.BasicClientCookie;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -73,7 +76,7 @@ public class DeezerAudioTrack extends ExtendedAudioTrack {
 
 	public SourceWithFormat getSource(HttpInterface httpInterface, String apiToken, String licenseToken) throws IOException, URISyntaxException {
 		var getTrackToken = new HttpPost(DeezerAudioSourceManager.PRIVATE_API_BASE + "?method=song.getData&input=3&api_version=1.0&api_token=" + apiToken);
-		getTrackToken.setEntity(new StringEntity("{\"sng_id\":\"" + this.trackInfo.identifier + "\"}", ContentType.APPLICATION_JSON));
+		getTrackToken.setEntity(new StringEntity("{\"SNG_ID\":\"" + this.trackInfo.identifier + "\"}", ContentType.APPLICATION_JSON));
 		var trackTokenJson = LavaSrcTools.fetchResponseAsJson(httpInterface, getTrackToken);
 		DeezerAudioSourceManager.checkResponse(trackTokenJson, "Failed to get track token");
 
@@ -82,10 +85,64 @@ public class DeezerAudioTrack extends ExtendedAudioTrack {
 		var getMediaURL = new HttpPost(DeezerAudioSourceManager.MEDIA_BASE + "/get_url");
 		getMediaURL.setEntity(new StringEntity("{\"license_token\":\"" + licenseToken + "\",\"media\":[{\"type\":\"FULL\",\"formats\":[" + formatFormats(this.sourceManager.getFormats()) + "]}],\"track_tokens\": [\"" + trackToken + "\"]}", ContentType.APPLICATION_JSON));
 
-		var json = LavaSrcTools.fetchResponseAsJson(httpInterface, getMediaURL);
-		DeezerAudioSourceManager.checkResponse(json, "Failed to get media URL");
+		try {
+			var json = LavaSrcTools.fetchResponseAsJson(httpInterface, getMediaURL);
+			DeezerAudioSourceManager.checkResponse(json, "Failed to get media URL");
+			return SourceWithFormat.fromResponse(json, trackTokenJson);
+		} catch (Exception e) {
+			if (this.sourceManager.getLegacyCdnKey() == null || this.sourceManager.getLegacyCdnKey().isEmpty()) {
+				throw e;
+			}
+			try {
+				return buildLegacyCdnSource(trackTokenJson);
+			} catch (Exception fallbackException) {
+				log.error("Legacy CDN fallback failed: {}", fallbackException.getMessage());
+				throw e;
+			}
+		}
+	}
 
-		return SourceWithFormat.fromResponse(json, trackTokenJson);
+	private SourceWithFormat buildLegacyCdnSource(JsonBrowser trackTokenJson) throws URISyntaxException {
+		var results = trackTokenJson.get("results");
+		var md5Origin = results.get("MD5_ORIGIN").text();
+		if (md5Origin == null || md5Origin.isEmpty()) {
+			throw new IllegalStateException("Missing MD5_ORIGIN for legacy CDN URL construction");
+		}
+
+		var sngId = !results.get("SNG_ID").safeText().isEmpty() ? results.get("SNG_ID").safeText() : this.trackInfo.identifier;
+		var mediaVersion = results.get("MEDIA_VERSION").safeText();
+		var legacyCdnKey = this.sourceManager.getLegacyCdnKey();
+
+		for (var format : this.sourceManager.getFormats()) {
+			var contentLength = results.get("FILESIZE_" + format.name()).asLong(0);
+			if (contentLength > 0) {
+				return new SourceWithFormat(buildLegacyCdnUrl(md5Origin, format.getQualityCode(), sngId, mediaVersion, legacyCdnKey), format, contentLength);
+			}
+		}
+
+		throw new IllegalStateException("No suitable format found for legacy CDN fallback");
+	}
+
+	private static String buildLegacyCdnUrl(String md5Origin, int qualityCode, String sngId, String mediaVersion, String key) {
+		try {
+			var step1 = md5Origin + "\u00a4" + qualityCode + "\u00a4" + sngId + "\u00a4" + mediaVersion;
+			var step1Md5 = new String(Hex.encodeHex(MessageDigest.getInstance("MD5").digest(step1.getBytes(StandardCharsets.ISO_8859_1)), true));
+			var step2 = step1Md5 + "\u00a4" + step1 + "\u00a4";
+
+			var step2Bytes = step2.getBytes(StandardCharsets.ISO_8859_1);
+			var paddedLen = (step2Bytes.length + 15) / 16 * 16;
+			var padded = new byte[paddedLen];
+			Arrays.fill(padded, (byte) ' ');
+			System.arraycopy(step2Bytes, 0, padded, 0, step2Bytes.length);
+
+			var cipher = Cipher.getInstance("AES/ECB/NoPadding");
+			cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key.getBytes(StandardCharsets.ISO_8859_1), "AES"));
+			var encrypted = cipher.doFinal(padded);
+
+			return "https://e-cdns-proxy-" + md5Origin.charAt(0) + ".dzcdn.net/mobile/1/" + new String(Hex.encodeHex(encrypted, true));
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to build legacy CDN URL", e);
+		}
 	}
 
 	public byte[] getTrackDecryptionKey() throws NoSuchAlgorithmException {
@@ -164,20 +221,26 @@ public class DeezerAudioTrack extends ExtendedAudioTrack {
 	}
 
 	public enum TrackFormat {
-		FLAC(true, FlacAudioTrack::new),
-		MP3_320(true, Mp3AudioTrack::new),
-		MP3_256(true, Mp3AudioTrack::new),
-		MP3_128(false, Mp3AudioTrack::new),
-		MP3_64(false, Mp3AudioTrack::new),
-		AAC_64(true, MpegAudioTrack::new); // not sure if this one is so better to be safe.
+		FLAC(true, 9, FlacAudioTrack::new),
+		MP3_320(true, 3, Mp3AudioTrack::new),
+		MP3_256(true, 5, Mp3AudioTrack::new),
+		MP3_128(false, 1, Mp3AudioTrack::new),
+		MP3_64(false, 10, Mp3AudioTrack::new),
+		AAC_64(true, 8, MpegAudioTrack::new); // not sure if this one is so better to be safe.
 
 		public static final TrackFormat[] DEFAULT_FORMATS = new TrackFormat[]{MP3_128, MP3_64};
 		private final boolean isPremiumFormat;
+		private final int qualityCode;
 		private final BiFunction<AudioTrackInfo, PersistentHttpStream, InternalAudioTrack> trackFactory;
 
-		TrackFormat(boolean isPremiumFormat, BiFunction<AudioTrackInfo, PersistentHttpStream, InternalAudioTrack> trackFactory) {
+		TrackFormat(boolean isPremiumFormat, int qualityCode, BiFunction<AudioTrackInfo, PersistentHttpStream, InternalAudioTrack> trackFactory) {
 			this.isPremiumFormat = isPremiumFormat;
+			this.qualityCode = qualityCode;
 			this.trackFactory = trackFactory;
+		}
+
+		public int getQualityCode() {
+			return this.qualityCode;
 		}
 
 		public static TrackFormat from(String format) {

--- a/plugin/src/main/java/com/github/topi314/lavasrc/plugin/LavaSrcPlugin.java
+++ b/plugin/src/main/java/com/github/topi314/lavasrc/plugin/LavaSrcPlugin.java
@@ -100,6 +100,9 @@ public class LavaSrcPlugin implements AudioPlayerManagerConfiguration, SearchMan
 		}
 		if (sourcesConfig.isDeezer() || lyricsSourcesConfig.isDeezer()) {
 			this.deezer = new DeezerAudioSourceManager(deezerConfig.getMasterDecryptionKey(), deezerConfig.getArl(), deezerConfig.getFormats());
+			if (deezerConfig.getLegacyCdnKey() != null && !deezerConfig.getLegacyCdnKey().isEmpty()) {
+				this.deezer.setLegacyCdnKey(deezerConfig.getLegacyCdnKey());
+			}
 		}
 
 		if (sourcesConfig.isYandexMusic() || lyricsSourcesConfig.isYandexMusic()) {
@@ -336,6 +339,9 @@ public class LavaSrcPlugin implements AudioPlayerManagerConfiguration, SearchMan
 					.map(deezerTrackFormat -> DeezerAudioTrack.TrackFormat.from(deezerTrackFormat.name()))
 					.toList()
 					.toArray(new DeezerAudioTrack.TrackFormat[0]));
+			}
+			if (deezerConfig.getLegacyCdnKey() != null) {
+				this.deezer.setLegacyCdnKey(deezerConfig.getLegacyCdnKey());
 			}
 		}
 

--- a/plugin/src/main/java/com/github/topi314/lavasrc/plugin/config/DeezerConfig.java
+++ b/plugin/src/main/java/com/github/topi314/lavasrc/plugin/config/DeezerConfig.java
@@ -11,6 +11,7 @@ public class DeezerConfig {
 	private String masterDecryptionKey;
 	private String arl;
 	private DeezerAudioTrack.TrackFormat[] formats;
+	private String legacyCdnKey;
 
 	public String getMasterDecryptionKey() {
 		return this.masterDecryptionKey;
@@ -34,6 +35,14 @@ public class DeezerConfig {
 
 	public void setFormats(DeezerAudioTrack.TrackFormat[] formats) {
 		this.formats = formats;
+	}
+
+	public String getLegacyCdnKey() {
+		return this.legacyCdnKey;
+	}
+
+	public void setLegacyCdnKey(String legacyCdnKey) {
+		this.legacyCdnKey = legacyCdnKey;
 	}
 
 }

--- a/protocol/src/commonMain/kotlin/com/github/topi314/lavasrc/protocol/Config.kt
+++ b/protocol/src/commonMain/kotlin/com/github/topi314/lavasrc/protocol/Config.kt
@@ -31,6 +31,7 @@ data class AppleMusicConfig(
 data class DeezerConfig(
     val arl: String? = null,
     val formats: List<DeezerTrackFormat>? = null,
+    val legacyCdnKey: String? = null,
 )
 
 @Suppress("unused")


### PR DESCRIPTION
It's an optional feature, but it works as tested. Some tracks such as https://www.deezer.com/us/track/13547842 only work with the fallback, I'm not entirely sure why. This implementation was inspired by https://github.com/PierrunoYT/Deezy/blob/main/deezy/src-tauri/src/deezer/mod.rs

I can communicate over discord if you need help testing