### PR TITLE
deezer: fix unreadable tracks not loading

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
@@ -266,7 +266,7 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 				continue;
 			}
 			if (!track.get("readable").asBoolean(false)) {
-				log.warn("Track {} by {} might fail because it is marked as not readable. Available countries: {}", track.get("title").text(), track.get("artist").get("name").safeText(), track.get("available_countries").text());
+				log.debug("Track {} by {} might fail because it is marked as not readable. Available countries: {}", track.get("title").text(), track.get("artist").get("name").safeText(), track.get("available_countries").text());
 			}
 			tracks.add(this.parseTrack(track, preview));
 		}
@@ -275,7 +275,7 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 
 	private AudioTrack parseTrack(JsonBrowser json, boolean preview) {
 		if (!json.get("readable").asBoolean(false)) {
-			log.warn("This track might fail because is marked as not readable. Available countries: {}", json.get("available_countries").text());
+			log.debug("This track might fail because is marked as not readable. Available countries: {}", json.get("available_countries").text());
 		}
 		var id = json.get("id").text();
 		return new DeezerAudioTrack(

--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioTrack.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioTrack.java
@@ -162,8 +162,8 @@ public class DeezerAudioTrack extends ExtendedAudioTrack {
 			// TODO: figure out caching these for the arl provided in the config
 			var tokens = this.getTokens(httpInterface);
 			var source = this.getSource(httpInterface, tokens.api, tokens.license);
-			var decryptionKeyId = source.getFallbackId() != null ? source.getFallbackId() : this.trackInfo.identifier;
-			try (var stream = new DeezerPersistentHttpStream(httpInterface, source.url, source.contentLength, this.getTrackDecryptionKey(decryptionKeyId))) {
+			var trackId = source.getFallbackId() != null ? source.getFallbackId() : this.trackInfo.identifier;
+			try (var stream = new DeezerPersistentHttpStream(httpInterface, source.url, source.contentLength, this.getTrackDecryptionKey(trackId))) {
 				processDelegate(source.format.trackFactory.apply(this.trackInfo, stream), executor);
 			}
 		}


### PR DESCRIPTION
- Implement fallback track handling in DeezerAudioTrack if missing ``RIGHTS`` array
- Allowing parsing and attempting to play songs that are marked as ``readable: false``, as some songs have country specific ones that are not even attempted due to the error being thrown.

Ex:
https://api.deezer.com/2.0/track/13547842
https://api.deezer.com/2.0/track/4288426

Both are the same song, but have different country lists. After fallback implementation, it automatically plays the one that is supported in the region it's hosted in