### PR TITLE
spotify: use /items endpoint for playlist tracks

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/spotify/SpotifySourceManager.java
@@ -555,7 +555,7 @@ public class SpotifySourceManager extends MirroringAudioSourceManager implements
 		var offset = 0;
 		var pages = 0;
 		do {
-			page = this.getJson(API_BASE + "playlists/" + id + "/tracks?limit=" + PLAYLIST_MAX_PAGE_ITEMS + "&offset=" + offset);
+			page = this.getJson(API_BASE + "playlists/" + id + "/items?limit=" + PLAYLIST_MAX_PAGE_ITEMS + "&offset=" + offset);
 			offset += PLAYLIST_MAX_PAGE_ITEMS;
 
 			for (var value : page.get("items").values()) {


### PR DESCRIPTION
The /tracks endpoint is deprecated; /items is the current Spotify API endpoint for fetching playlist contents.